### PR TITLE
Speed up CI/CD Pipeline

### DIFF
--- a/.github/workflows/pr-pipeline.yaml
+++ b/.github/workflows/pr-pipeline.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-
   pull_request:
     branches:
       - main
@@ -16,6 +15,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+
+      - name: Restore Yarn cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - name: Set up Node.js
         uses: actions/setup-node@v2
@@ -36,6 +43,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+
+      - name: Restore Yarn cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - name: Set up Node.js
         uses: actions/setup-node@v2
@@ -70,6 +85,14 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v2
+
+      - name: Restore Yarn cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
       - name: Deploy to Vercel
         uses: amondnet/vercel-action@v20 #deploy

--- a/.github/workflows/pr-pipeline.yaml
+++ b/.github/workflows/pr-pipeline.yaml
@@ -28,24 +28,6 @@ jobs:
       - name: Build
         run: yarn build
 
-  test:
-    needs: build
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: 19
-          cache: 'yarn'
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
       - name: Prettier Check
         run: yarn prettier --check .
 
@@ -56,7 +38,7 @@ jobs:
         run: yarn test:ci
 
   deploy:
-    needs: test
+    needs: build
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/pr-pipeline.yaml
+++ b/.github/workflows/pr-pipeline.yaml
@@ -16,18 +16,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Restore Yarn cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
           node-version: 19
+          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -44,18 +37,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Restore Yarn cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
           node-version: 19
+          cache: 'yarn'
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -85,14 +71,6 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v2
-
-      - name: Restore Yarn cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
 
       - name: Deploy to Vercel
         uses: amondnet/vercel-action@v20 #deploy


### PR DESCRIPTION
## Summary

Add yarn cache into pipeline

## Changes

- Use yarn cache in pipeline
- Merged build and test stage
- Should speed up the pipeline by about 5 minutes


## Checklist

- [x] Test coverage has not deteriorated
- [x] CI is green
- [x] Added hours into project log
- [x] Strikethrough in sprint [google slides](https://docs.google.com/presentation/d/1MSBQBfoO3J3BjRIPc7SOupEhpgNNj9Tvole45ULLzBc/edit).
