### PR TITLE
Security patch (vite)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "remark-gfm": "^3.0.1",
     "tailwind-merge": "^1.12.0",
     "tailwindcss": "3.3.2",
-    "typescript": "5.0.4"
+    "typescript": "5.0.4",
+    "vite": "^4.3.9"
   },
   "devDependencies": {
     "@testing-library/dom": "^9.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12764,6 +12764,17 @@ vite-node@^0.28.5:
   optionalDependencies:
     fsevents "~2.3.2"
 
+vite@^4.3.9:
+  version "4.3.9"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-4.3.9.tgz#db896200c0b1aa13b37cdc35c9e99ee2fdd5f96d"
+  integrity sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==
+  dependencies:
+    esbuild "^0.17.5"
+    postcss "^8.4.23"
+    rollup "^3.21.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 vm2@^3.9.17:
   version "3.9.18"
   resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.18.tgz#d919848bee191a0410c5cc1c5aac58adfd03ce9a"


### PR DESCRIPTION
## Summary

Updated Vite

## Changes

- Vite to 4.3.9

## Checklist

- [] Test coverage has not deteriorated
- [] CI is green
- [ ] Added hours into project log
- [ ] Strikethrough in sprint [google slides](https://docs.google.com/presentation/d/1MSBQBfoO3J3BjRIPc7SOupEhpgNNj9Tvole45ULLzBc/edit).
